### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Simple, Customizable notification panel
 ## Requirements
 
 - Swift 2.1
-- XCode 6
+- Xcode 6
 - iOS 8.0 or above
 
 ## Installation


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
